### PR TITLE
19_Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,5 +1,0 @@
-main {
-  max-width: 700px;
-  margin: 0 auto;
-  padding: 1rem;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,21 +5,6 @@ main {
 }
 
 #movie .movie-title {
-  @media screen and (min-width: 0px){
-    font-size: 40px;
-  }
-
-  @media screen and (min-width: 992px){
-    font-size: 20px;
-  }
+  font-size: 20px;
 }
 
-#movie .movie-contents {
-  @media screen and (min-width: 992px){
-    padding-bottom: 70px;
-  }
-
-  @media screen and (min-width: 0px){
-    padding-bottom: 70px;
-  }
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,25 @@
+main {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+#movie .movie-title {
+  @media screen and (min-width: 0px){
+    font-size: 40px;
+  }
+
+  @media screen and (min-width: 992px){
+    font-size: 20px;
+  }
+}
+
+#movie .movie-contents {
+  @media screen and (min-width: 992px){
+    padding-bottom: 70px;
+  }
+
+  @media screen and (min-width: 0px){
+    padding-bottom: 70px;
+  }
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-
+    @movies = Movie.all
   end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,27 @@
-<h1>TOPページ</h1>
+<div id="container">
+  <section id="movie">
+    <div class="container">
+      <div class="rows">
+        <section class="text-center">
+          <% @movies.each.with_index(1) do |movie,i| %>
+            <div class="col-xs-12">
+              <div class="movie-title">
+                Lv.<%= i %>：<%= movie.title %>
+              </div>
+              <div class="movie-contents">
+                <iframe width="560" height="315" src="<%= movie.url %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+              </div>
+            </div>
+          <% end %>
+          <div class="paginate-container">
+            <%# ページネーション表示 %>
+            <%# <button type="button" class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Tooltip on top">
+              Tooltip on top
+            </button> %>
+          </div>
+        </section>
+      </div>
+    </div>
+  </section>
+</div>
 
-<button type="button" class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Tooltip on top">
-    Tooltip on top
-</button>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -4,7 +4,7 @@
       <div class="rows">
         <section class="text-center">
           <% @movies.each.with_index(1) do |movie,i| %>
-            <div class="col-xs-12">
+            <div class="col-xs-12 my-5">
               <div class="movie-title">
                 Lv.<%= i %>：<%= movie.title %>
               </div>
@@ -14,10 +14,6 @@
             </div>
           <% end %>
           <div class="paginate-container">
-            <%# ページネーション表示 %>
-            <%# <button type="button" class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Tooltip on top">
-              Tooltip on top
-            </button> %>
           </div>
         </section>
       </div>


### PR DESCRIPTION
動画教材のページを実装しました。

#### 作業内容
- index.html.erbにHTMLでサイト構造を記述
- movies_controllerで全データ(Movie.all)を@moviesへ代入
- index.html.erbで@moviesのデータ表示に記述変更（タイトル、動画URL表示）
- application.cssの拡張子を .scss へ変更
- application.scssへCSSを記述

#### 参考資料
- 逆転教材動画ページ