### PR TITLE
20_Rails動画教材ページネーションの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'devise-i18n'
 
 gem 'activeadmin'
 
+gem 'kaminari'
+
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ DEPENDENCIES
   devise
   devise-i18n
   jbuilder (~> 2.7)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,7 @@ main {
   font-size: 20px;
 }
 
+#movie .paginate-container {
+  display: flex;
+  justify-content: center;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.all
+    @movies = Movie.page(params[:page]).per(10)
   end
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -14,6 +14,7 @@
             </div>
           <% end %>
           <div class="paginate-container">
+            <%= paginate @movies %>
           </div>
         </section>
       </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -3,7 +3,7 @@
     <div class="container">
       <div class="rows">
         <section class="text-center">
-          <% @movies.each.with_index(1) do |movie,i| %>
+          <% @movies.each.with_index(@movies.offset_value + 1) do |movie,i| %>
             <div class="col-xs-12 my-5">
               <div class="movie-title">
                 Lv.<%= i %>：<%= movie.title %>


### PR DESCRIPTION
動画教材ページへページネーションを追加しました。

#### 作業内容
- Gemfileへ`gem 'kaminari'`を追加
- movies_controller.rbでkaminari用のコマンドで１ページ10個までにデータ表示制限
- movies/index.html.erbへページネーション表示タグ`<%= paginate @movies %>`を追加
- `rails g kaminari:views bootstrap4`コマンドでkaminari用の部分テンプレートファイル作成＆適用
- application.scssでページネーションの位置を中央に表示

#### 参考資料
- 逆転サロン動画教材ページ
- https://pikawaka.com/rails/kaminari
- http://buzzword111.hatenablog.com/entry/2014/03/14/104630
- https://qiita.com/d0ne1s/items/58c3d0e08ce7ede94384