### PR TITLE
23_質問集の質問詳細ページを実装

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -15,6 +15,10 @@ class QuestionsController < ApplicationController
     end
   end
 
+  def show
+    @question = Question.find[:id]
+  end
+
   private
 
   def question_params

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -16,7 +16,7 @@ class QuestionsController < ApplicationController
   end
 
   def show
-    @question = Question.find[:id]
+    @question = Question.find(params[:id])
   end
 
   private

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,5 @@
 class Question < ApplicationRecord
   validates :title, presence: true
   validates :detail, presence: true
+  has_many :solutions
 end

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -1,0 +1,3 @@
+class Solution < ApplicationRecord
+  belongs_to :question
+end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -14,7 +14,7 @@
         <% @aws_texts.each.with_index(1) do |aws_text, i| %>
       <tr>
         <td><%= "#{i}" %></td>
-        <td><%= link_to aws_text.title, aws_text_path(aws_text) %></td>
+        <td><%= link_to aws_text.title, aws_text_path(aws_text), target: :_blank %></td>
       </tr>
      <% end %>
     </table>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -22,8 +22,7 @@
   <section id="questions">
     <div class="container">
       <% @questions.each do |question| %>
-        <div class="question-container">
-          <a href="/question/<%= question.id %>">
+          <a href="/questions/<%= question.id%>">
             <div class="question">
               <div class="row">
                 <div class="col-md-7">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,0 +1,10 @@
+<div class="container" >
+  <div class="question">
+    <h3>【質問】</h3>
+    <% @question.title %>
+    <%= markdown(@question.title).html_safe %>
+    <h3>【詳細】</h3>
+    <% @question.detail %>
+    <%= markdown(@question.detail).html_safe %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'movies#index'
-  resources :questions
+  resources :questions, only: [:index, :show]
   resources :aws_texts, only: [:index, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'movies#index'
-  resources :questions, only: [:index, :show]
+  resources :questions, only: [:index, :create, :show]
   resources :aws_texts, only: [:index, :show]
 end

--- a/db/migrate/20200514051204_create_solutions.rb
+++ b/db/migrate/20200514051204_create_solutions.rb
@@ -1,0 +1,9 @@
+class CreateSolutions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :solutions do |t|
+      t.integer :question_id
+      t.text :answer
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_03_135453) do
+ActiveRecord::Schema.define(version: 2020_05_14_051204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,13 @@ ActiveRecord::Schema.define(version: 2020_05_03_135453) do
   create_table "questions", force: :cascade do |t|
     t.string "title"
     t.text "detail"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "solutions", force: :cascade do |t|
+    t.integer "question_id"
+    t.text "answer"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
Railsガイド(https://railsguides.jp/association_basics.html) を参考に

- solutionsテーブルを作成し，questionsテーブルと関連づけを行う
- Markdownが使えるように質問詳細ページを作成
- 質問一覧ページから詳細ページへのリンクを付ける

以上を行いました。
また、作業中に、以前のタスク「18_AWSテキスト教材詳細ページの実装」の

- 一覧ページの「内容」から詳細ページに移動できるようにする

のページ表示が別タグになっていないと思い修正しました。

作業が混合してしまい申し訳ありません。
ご確認、よろしくお願い致します。